### PR TITLE
nodeIntegration must be nested within webPreferences

### DIFF
--- a/src/OauthGithub.js
+++ b/src/OauthGithub.js
@@ -18,7 +18,7 @@ export default class AuthWindow {
   startRequest(callback) {
     this.callback = callback;
     app.on('ready', () => {
-      this.window = new BrowserWindow({ width: 800, height: 600, 'node-integration': false });
+      this.window = new BrowserWindow({ width: 800, height: 600, webPreferences: {nodeIntegration: false}});
       var authURL = 'https://github.com/login/oauth/authorize?client_id=' + this.clientId + '&scope=' + this.scopes;
       this.window.loadURL(authURL);
       this.window.show();


### PR DESCRIPTION
There's currently a bug where GitHub's "Authorize Application" button is disabled on their oauth page because the node integration isn't correctly being turned off. Apparently the API changed after Electron 1.0 and the preference needs to be nested within `webPreferences`.